### PR TITLE
Add some security rules

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,13 +16,15 @@ import { PolicyPack } from "@pulumi/policy";
 
 import { compute } from "./compute";
 import { elasticsearch } from "./elasticsearch";
+import { security } from "./security";
 import { storage } from "./storage";
 
 // Create a new Policy Pack.
 export const policyPack = new PolicyPack("pulumi-awsguard", {
     policies: [
-        ...storage,
-        ...elasticsearch,
         ...compute,
+        ...elasticsearch,
+        ...security,
+        ...storage,
     ],
 });

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     },
     "dependencies": {
         "@pulumi/aws": "^1.0.0",
+        "@pulumi/policy": "dev",
         "@pulumi/pulumi": "^1.0.0",
-        "@pulumi/policy": "dev"
+        "aws-sdk": "^2.545.0",
+        "aws-sdk-mock": "^4.5.0"
     },
     "devDependencies": {
         "@types/chai": "^4.2.3",

--- a/security.ts
+++ b/security.ts
@@ -1,0 +1,120 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as AWS from "aws-sdk";
+
+import * as aws from "@pulumi/aws";
+
+import { EnforcementLevel, ResourceValidationPolicy, validateTypedResource } from "@pulumi/policy";
+
+// Milliseconds in a day.
+const msInDay = 24 * 60 * 60 * 1000;
+
+export const security: ResourceValidationPolicy[] = [
+    AcmCheckCertificateExpiration("mandatory", 14 /* max days before certificate expires */),
+    CmkBackingKeyRotationEnabled("mandatory"),
+    IamAccessKeysRotated("mandatory", 90 /* max key age in days */),
+    IamMfaEnabledForConsoleAccess("mandatory"),
+];
+
+export function AcmCheckCertificateExpiration(enforcementLevel: EnforcementLevel = "advisory", maxDaysUntilExpiration: number): ResourceValidationPolicy {
+    return {
+        name: "acm-certificate-expiration",
+        description: "Checks whether an ACM certificate has expired. Certificates provided by ACM are automatically renewed. ACM does not automatically renew certificates that you import.",
+        enforcementLevel: enforcementLevel,
+        validateResource: validateTypedResource(aws.iam.AccessKey.isInstance, async (instance, args, reportViolation) => {
+            // Fetch the full ACM certificate using the AWS SDK to get its expiration date.
+            const acm = new AWS.ACM();
+            const describeCertResp = await acm.describeCertificate({ CertificateArn: instance.id }).promise();
+
+            const cert = describeCertResp.Certificate;
+            if (cert && cert.NotAfter) {
+                let daysUntilExpiry = (cert.NotAfter.getTime() - Date.now()) / msInDay;
+                daysUntilExpiry = Math.floor(daysUntilExpiry);
+
+                if (daysUntilExpiry < maxDaysUntilExpiration) {
+                    reportViolation(`certificate expires in ${daysUntilExpiry} (max allowed ${maxDaysUntilExpiration} days)`);
+                }
+            }
+        }),
+    };
+}
+
+export function CmkBackingKeyRotationEnabled(enforcementLevel: EnforcementLevel = "advisory"): ResourceValidationPolicy {
+    return {
+        name: "cmk-backing-key-rotation-enabled",
+        description: "Checks that key rotation is enabled for each customer master key (CMK). Checks that key rotation is enabled for specific key object. Does not apply to CMKs that have imported key material.",
+        enforcementLevel: enforcementLevel,
+        validateResource: validateTypedResource(aws.kms.Key.isInstance, async (instance, args, reportViolation) => {
+            if (!instance.enableKeyRotation) {
+                reportViolation("CMK does not have the key rotation setting enabled");
+            }
+        }),
+    };
+}
+
+export function IamAccessKeysRotated(enforcementLevel: EnforcementLevel = "advisory", maxKeyAge: number): ResourceValidationPolicy {
+    if (maxKeyAge < 1 || maxKeyAge > 2 * 365) {
+        throw new Error("Invalid maxKeyAge.");
+    }
+
+    return {
+        name: "access-keys-rotated",
+        description: "Checks whether an access key have been rotated within maxKeyAge days.",
+        enforcementLevel: enforcementLevel,
+        validateResource: validateTypedResource(aws.iam.AccessKey.isInstance, async (instance, args, reportViolation) => {
+            // Skip any access keys that haven't yet been provisioned or whose status is inactive.
+            if (!instance.id || instance.status !== "Active") {
+                return;
+            }
+
+            const iam = new AWS.IAM();
+
+            // Use the AWS SDK to list the access keys for the user, which will contain the key's creation date.
+            let paginationToken = undefined;
+
+            let accessKeysResp: AWS.IAM.ListAccessKeysResponse;
+            do {
+                accessKeysResp = await iam.listAccessKeys({ UserName: instance.user, Marker: paginationToken }).promise();
+                for (const accessKey of accessKeysResp.AccessKeyMetadata) {
+                    if (accessKey.AccessKeyId === instance.id && accessKey.CreateDate) {
+                        let daysSinceCreated = (Date.now() - accessKey.CreateDate!.getTime()) / msInDay;
+                        daysSinceCreated = Math.floor(daysSinceCreated);
+                        if (daysSinceCreated > maxKeyAge) {
+                            reportViolation(`access key must be rotated within ${maxKeyAge} days (key is ${daysSinceCreated} days old)`);
+                        }
+                    }
+                }
+
+                paginationToken = accessKeysResp.Marker;
+            } while (accessKeysResp.IsTruncated);
+        }),
+    };
+}
+
+export function IamMfaEnabledForConsoleAccess(enforcementLevel: EnforcementLevel = "advisory"): ResourceValidationPolicy {
+    return {
+        name: "mfa-enabled-for-iam-console-access",
+        description: "Checks whether multi-factor Authentication (MFA) is enabled for an IAM user that use a console password.",
+        enforcementLevel: enforcementLevel,
+        validateResource: validateTypedResource(aws.iam.UserLoginProfile.isInstance, async (instance, args, reportViolation) => {
+            const iam = new AWS.IAM();
+            const mfaDevicesResp = await iam.listMFADevices({ UserName: instance.user }).promise();
+            // We don't bother with paging through all MFA devices, since we only check that there is at least one.
+            if (mfaDevicesResp.MFADevices.length === 0) {
+                reportViolation(`no MFA device enabled for IAM User '${instance.user}'`);
+            }
+        }),
+    };
+}

--- a/tests/security.spec.ts
+++ b/tests/security.spec.ts
@@ -1,0 +1,248 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import "mocha";
+
+import * as aws from "@pulumi/aws";
+
+import * as security from "../security";
+import { assertHasViolation, assertNoViolations, daysFromNow, fakeResource, PolicyViolation } from "./util";
+
+import { fail } from "assert";
+
+import * as AWS from "aws-sdk";
+import * as AWSMock from "aws-sdk-mock";
+import { DescribeCertificateRequest } from "aws-sdk/clients/acm";
+import { ListAccessKeysRequest, ListMFADevicesRequest } from "aws-sdk/clients/iam";
+
+describe("#IamAccessKeysRotated", () => {
+    const maxKeyAge = 30;
+    const policy = security.IamAccessKeysRotated("mandatory", maxKeyAge);
+    const policyArgs = {
+        type: (<any>aws.iam.AccessKey).__pulumiType,
+        props: {},
+    };
+
+    const testAccessKeyId = "AKITESTKEYID";
+    const testUserEmail = "test-user@example.com";
+
+    it("reports no violations for inactive keys", async () => {
+        await assertNoViolations(policy, policyArgs);
+
+        policyArgs.props = fakeResource<aws.iam.AccessKey>({ status: "Inactive" });
+        await assertNoViolations(policy, policyArgs);
+    });
+
+    it("reports no violation for unexpired keys", async () => {
+        AWSMock.setSDKInstance(AWS);
+        AWSMock.mock("IAM", "listAccessKeys", (params: ListAccessKeysRequest, callback: Function) => {
+            const resp: AWS.IAM.ListAccessKeysResponse = {
+                IsTruncated: false,
+                AccessKeyMetadata: [
+                    {
+                        AccessKeyId: testAccessKeyId,
+                        CreateDate: new Date(),
+                    },
+                ],
+            };
+
+            callback(null, resp);
+        });
+
+        policyArgs.props = fakeResource<aws.iam.AccessKey>({
+            id: testAccessKeyId,
+            status: "Active",
+            user: testUserEmail,
+        });
+        await assertNoViolations(policy, policyArgs);
+    });
+
+    it("Reports a violation for unrotated key", async () => {
+        const longTimeAgo = daysFromNow(-180);
+
+        AWSMock.restore("IAM", "listAccessKeys");
+        AWSMock.setSDKInstance(AWS);
+
+        // In mocking listAccessKeys, we are also confirming that function uses
+        // pagination. We return two different responses in sequence.
+        let timeCalled = 0;
+        AWSMock.mock("IAM", "listAccessKeys", (params: ListAccessKeysRequest, callback: Function) => {
+            let resp: AWS.IAM.ListAccessKeysResponse;
+            switch (timeCalled) {
+                case 0:
+                    timeCalled++;
+
+                    // First response contains a single key that is still valid.
+                    resp = {
+                        IsTruncated: true,
+                        Marker: "timeCalled-1",
+                        AccessKeyMetadata: [
+                            {
+                                AccessKeyId: testAccessKeyId+"-not-expired",
+                                CreateDate: new Date(),
+                            },
+                        ],
+                    };
+                    break;
+
+                case 1:
+                    timeCalled++;
+                    if (params.Marker !== "timeCalled-1") {
+                        fail("parameters to listAccessKeys included wrong marker");
+                    }
+
+                    // Second response contains an expired key.
+                    resp = {
+                        IsTruncated: false,
+                        AccessKeyMetadata: [
+                            {
+                                AccessKeyId: testAccessKeyId,
+                                CreateDate: longTimeAgo,
+                            },
+                        ],
+                    };
+                    break;
+
+                default:
+                    fail("listAccessKeys called unexpected number of times");
+                    break;
+            }
+
+            callback(null, resp!);
+        });
+
+        policyArgs.props = fakeResource<aws.iam.AccessKey>({
+            id: testAccessKeyId,
+            status: "Active",
+            user: "test-user@pulumi.com",
+        });
+        await assertHasViolation(policy, policyArgs, {
+            message: "access key must be rotated within 30 days (key is 180 days old)",
+        } as PolicyViolation);
+    });
+});
+
+describe("#IamMfaEnabledForConsoleAccess", () => {
+    const policy = security.IamMfaEnabledForConsoleAccess("mandatory");
+    const policyArgs = {
+        type: (<any>aws.iam.UserLoginProfile).__pulumiType,
+        props: {},
+    };
+
+    const testUserEmail = "test-user@example.com";
+
+    it("Does not report a violation if an MFA device is attached", async () => {
+        policyArgs.props = fakeResource<aws.iam.UserLoginProfile>({ user: testUserEmail });
+
+        AWSMock.setSDKInstance(AWS);
+        AWSMock.mock("IAM", "listMFADevices", (params: ListMFADevicesRequest, callback: Function) => {
+            const resp: AWS.IAM.ListMFADevicesResponse = {
+                MFADevices: [
+                    {
+                        UserName: testUserEmail,
+                        SerialNumber: "xxx-xxxx-xxxx",
+                        EnableDate: new Date(),
+                    },
+                ],
+                IsTruncated: false,
+            };
+            callback(null, resp);
+        });
+
+        assertNoViolations(policy, policyArgs);
+    });
+
+    it("Reports a violation if no MFA devices are attached", async () => {
+        policyArgs.props = fakeResource<aws.iam.UserLoginProfile>({ user: testUserEmail });
+
+        AWSMock.setSDKInstance(AWS);
+        AWSMock.restore("IAM", "listMFADevices");
+        AWSMock.mock("IAM", "listMFADevices", (params: ListMFADevicesRequest, callback: Function) => {
+            const resp: AWS.IAM.ListMFADevicesResponse = {
+                MFADevices: [],
+            };
+            callback(null, resp);
+        });
+
+        assertHasViolation(policy, policyArgs, {
+            message: `no MFA device enabled for IAM User '${testUserEmail}'`,
+        } as PolicyViolation);
+    });
+});
+
+describe("#AcmCheckCertificateExpiration", () => {
+    const maxDaysTillExpires = 14;
+    const policy = security.AcmCheckCertificateExpiration("mandatory", maxDaysTillExpires);
+    const policyArgs = {
+        type: (<any>aws.acm.Certificate).__pulumiType,
+        props: {},
+    };
+
+    const testCertificateArn = "arn:aws:acm:us-east-1:222222222222:certificate/aaaaaaaa-ffff-2222-eeee-1111111111111";
+
+    it("Does not fail if the certificate is current", async () => {
+        const monthFromNow = daysFromNow(30);
+
+        AWSMock.setSDKInstance(AWS);
+        AWSMock.mock("ACM", "describeCertificate", (params: DescribeCertificateRequest, callback: Function) => {
+            const resp: AWS.ACM.DescribeCertificateResponse = {
+                Certificate: {
+                    NotAfter: monthFromNow,
+                },
+            };
+            callback(null, resp);
+        });
+
+        policyArgs.props = fakeResource<aws.acm.Certificate>({ id: testCertificateArn });
+        await assertNoViolations(policy, policyArgs);
+    });
+
+    it("Fails if the certificate close to expiration", async () => {
+        const weekFromNow = daysFromNow(7);
+
+        AWSMock.setSDKInstance(AWS);
+        AWSMock.restore("ACM", "describeCertificate");
+        AWSMock.mock("ACM", "describeCertificate", (params: DescribeCertificateRequest, callback: Function) => {
+            const resp: AWS.ACM.DescribeCertificateResponse = {
+                Certificate: {
+                    NotAfter: weekFromNow,
+                },
+            };
+            callback(null, resp);
+        });
+
+        policyArgs.props = fakeResource<aws.acm.Certificate>({ id: testCertificateArn });
+        await assertNoViolations(policy, policyArgs);
+    });
+});
+
+describe("#CmkBackingKeyRotationEnabled", () => {
+    const policy = security.CmkBackingKeyRotationEnabled("mandatory");
+    const policyArgs = {
+        type: (<any>aws.kms.Key).__pulumiType,
+        props: {},
+    };
+
+    it("Fails if key does not have rotation enabled", async() => {
+        policyArgs.props = fakeResource<aws.kms.Key>({ enableKeyRotation: false });
+        await assertHasViolation(policy, policyArgs, {
+            message: "CMK does not have the key rotation setting enabled",
+        } as PolicyViolation);
+    });
+
+    it("Does not fail if the key is configured to be rotated", async() => {
+        policyArgs.props = fakeResource<aws.kms.Key>({ enableKeyRotation: true });
+        await assertNoViolations(policy, policyArgs);
+    });
+});

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -65,7 +65,7 @@ export async function assertHasViolation(
     resPolicy: policy.ResourceValidationPolicy, args: policy.ResourceValidationArgs, wantViolation: PolicyViolation) {
     const allViolations = await runPolicy(resPolicy, args);
     if (!allViolations || allViolations.length === 0) {
-        assert.fail("no violations reported");
+        assert.fail("no violations reported, but expected one");
     } else {
         for (const reportedViolation of allViolations) {
             // If we expect a specific URN, require that in the reported violation.
@@ -87,6 +87,17 @@ export async function assertHasViolation(
             }
         }
 
+        console.log("The expected violation was not found. Got the following instead:");
+        for (const reportedViolation of allViolations) {
+            console.log(`- ${reportedViolation.message} (urn="${reportedViolation.urn})`);
+        }
         assert.fail(`violation with substrings message:'${wantViolation.message}' urn:'${wantViolation.urn}' not found.`);
     }
+}
+
+// Returns "now", d days in the future or past.
+export function daysFromNow(days: number): Date {
+    const date = new Date();
+    date.setDate(date.getDate() + days);
+    return date;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,11 +13,12 @@
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "forceConsistentCasingInFileNames": true,
-        "strictNullChecks": true,
+        "strictNullChecks": true
     },
     "files": [
         "index.ts",
         "tests/elasticsearch.spec.ts",
+        "tests/security.spec.ts",
         "tests/util.ts"
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -209,6 +209,35 @@
   resolved "https://registry.yarnpkg.com/@pulumi/query/-/query-0.3.0.tgz#f496608e86a18c3dd31b6c533408e2441c29071d"
   integrity sha512-xfo+yLRM2zVjVEA4p23IjQWzyWl1ZhWOGobsBqRpIarzLvwNH/RAGaoehdxlhx4X92302DrpdIFgTICMN4P38w==
 
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.4.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.6.0.tgz#ec7670432ae9c8eb710400d112c201a362d83393"
+  integrity sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@^3.2.1":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.2.2.tgz#771c60dfa75ea7f2d68e3b94c7e888a78781372c"
+  integrity sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^3.1.0"
+
+"@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.3.tgz#46682efd9967b259b81136b9f120fd54585feb4a"
+  integrity sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==
+  dependencies:
+    "@sinonjs/commons" "^1.3.0"
+    array-from "^2.1.1"
+    lodash "^4.17.15"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+
 "@types/bytebuffer@^5.0.40":
   version "5.0.40"
   resolved "https://registry.yarnpkg.com/@types/bytebuffer/-/bytebuffer-5.0.40.tgz#d6faac40dcfb09cd856cdc4c01d3690ba536d3ee"
@@ -316,6 +345,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
+  integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
+
 arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
@@ -339,6 +373,15 @@ assertion-error@^1.1.0:
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
   integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
+aws-sdk-mock@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk-mock/-/aws-sdk-mock-4.5.0.tgz#9de5feefaf9c755f22fcf029db3f202599a9219e"
+  integrity sha512-PAZKbQsdaVVoMr1JZbi04FUrkxCK16qnwBWLm4keeBrEfqYab/cFNsn5IVp/ThdMQpJGYHnmqUPyFq1plKaHZg==
+  dependencies:
+    aws-sdk "^2.483.0"
+    sinon "^7.3.2"
+    traverse "^0.6.6"
+
 aws-sdk@^2.0.0:
   version "2.554.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.554.0.tgz#7a58cbaec5f9e4c2780910b458a77022557c2fc8"
@@ -353,6 +396,21 @@ aws-sdk@^2.0.0:
     url "0.10.3"
     uuid "3.3.2"
     xml2js "0.4.19"
+
+aws-sdk@^2.483.0, aws-sdk@^2.545.0:
+  version "2.568.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.568.0.tgz#730a3897a08ceab8010f3f99119dc262bc6d06c3"
+  integrity sha512-jPvhiJV2iLyWbJJDM01gvUCzeChWUeRMkIr6dsHu+leH2QnzvGNunTwMGculKE1jouXatajZEoA9bdqfosranw==
+  dependencies:
+    buffer "^4.9.1"
+    events "^1.1.1"
+    ieee754 "^1.1.13"
+    jmespath "^0.15.0"
+    querystring "^0.2.0"
+    sax "^1.2.1"
+    url "^0.10.3"
+    uuid "^3.3.2"
+    xml2js "^0.4.19"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -391,6 +449,15 @@ buffer@4.9.1:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
   integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
+
+buffer@^4.9.1:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -626,7 +693,7 @@ dezalgo@^1.0.0:
     asap "^2.0.0"
     wrappy "1"
 
-diff@3.5.0, diff@^3.1.0:
+diff@3.5.0, diff@^3.1.0, diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
@@ -693,7 +760,7 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-events@1.1.1:
+events@1.1.1, events@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
@@ -899,7 +966,7 @@ iconv-lite@^0.4.4:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-ieee754@1.1.13, ieee754@^1.1.4:
+ieee754@1.1.13, ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
@@ -990,6 +1057,11 @@ is-symbol@^1.0.2:
   dependencies:
     has-symbols "^1.0.0"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -1052,7 +1124,7 @@ istanbul-reports@^2.2.4:
   dependencies:
     handlebars "^4.1.2"
 
-jmespath@0.15.0:
+jmespath@0.15.0, jmespath@^0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
   integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
@@ -1079,6 +1151,11 @@ json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
+
+just-extend@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
+  integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
 
 lcid@^1.0.0:
   version "1.0.0"
@@ -1131,6 +1208,11 @@ log-symbols@2.2.0:
   integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
   dependencies:
     chalk "^2.0.1"
+
+lolex@^4.1.0, lolex@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-4.2.0.tgz#ddbd7f6213ca1ea5826901ab1222b65d714b3cd7"
+  integrity sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==
 
 long@^4.0.0:
   version "4.0.0"
@@ -1281,6 +1363,17 @@ nested-error-stacks@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz#0fbdcf3e13fe4994781280524f8b96b0cdff9c61"
   integrity sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
+
+nise@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.5.2.tgz#b6d29af10e48b321b307e10e065199338eeb2652"
+  integrity sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==
+  dependencies:
+    "@sinonjs/formatio" "^3.2.1"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    lolex "^4.1.0"
+    path-to-regexp "^1.7.0"
 
 node-addon-api@^1.6.0:
   version "1.7.1"
@@ -1518,6 +1611,13 @@ path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
@@ -1591,7 +1691,7 @@ punycode@1.3.2:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
-querystring@0.2.0:
+querystring@0.2.0, querystring@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
@@ -1728,7 +1828,7 @@ sax@1.2.1:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
   integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
 
-sax@>=0.6.0, sax@^1.2.4:
+sax@>=0.6.0, sax@^1.2.1, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -1752,6 +1852,19 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
+sinon@^7.3.2:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.5.0.tgz#e9488ea466070ea908fd44a3d6478fd4923c67ec"
+  integrity sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==
+  dependencies:
+    "@sinonjs/commons" "^1.4.0"
+    "@sinonjs/formatio" "^3.2.1"
+    "@sinonjs/samsam" "^3.3.3"
+    diff "^3.5.0"
+    lolex "^4.2.0"
+    nise "^1.5.2"
+    supports-color "^5.5.0"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -1913,7 +2026,7 @@ supports-color@6.0.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -1955,6 +2068,11 @@ to-fast-properties@^2.0.0:
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
   integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
 
+traverse@^0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
+  integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
+
 ts-node@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
@@ -1980,7 +2098,7 @@ ts-node@^8.4.1:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
@@ -2008,7 +2126,7 @@ upath@^1.1.0:
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
 
-url@0.10.3:
+url@0.10.3, url@^0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
   integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
@@ -2026,6 +2144,14 @@ util-promisify@^2.1.0:
   resolved "https://registry.yarnpkg.com/util-promisify/-/util-promisify-2.1.0.tgz#3c2236476c4d32c5ff3c47002add7c13b9a82a53"
   integrity sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=
   dependencies:
+    object.getownpropertydescriptors "^2.0.3"
+
+util.promisify@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
+  integrity sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==
+  dependencies:
+    define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
 uuid@3.3.2:
@@ -2113,6 +2239,20 @@ xml2js@0.4.19:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
+
+xml2js@^0.4.19:
+  version "0.4.22"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.22.tgz#4fa2d846ec803237de86f30aa9b5f70b6600de02"
+  integrity sha512-MWTbxAQqclRSTnehWWe5nMKzI3VmJ8ltiJEco8akcC6j3miOhjjfzKum5sId+CWhfxdOs/1xauYr8/ZDBtQiRw==
+  dependencies:
+    sax ">=0.6.0"
+    util.promisify "~1.0.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlbuilder@~9.0.1:
   version "9.0.7"


### PR DESCRIPTION
This is a work in progress for the following rules:

- access-keys-rotated
- acm-certificate-expiration-check
- cmk-backing-key-rotation-enabled
- mfa-enabled-for-iam-console-access
- root-account-hardware-mfa-enabled
- root-account-mfa-enabled

There are a number of open issues in here, including the
precise semantics of some of these rules, how our "state file"
versus "live state" semantics are meant to work here (especially
for some of the time-bound things like "certificate expires in X
days"), whether root account analysis makes sense for Pulumi as
a result, and testability overall.

But it's a start :-)