### PR TITLE
Simplify createResourceValidationArgs unit test helper

### DIFF
--- a/tests/elasticsearch.spec.ts
+++ b/tests/elasticsearch.spec.ts
@@ -24,32 +24,32 @@ describe("#ElasticsearchEncryptedAtRest", () => {
     const domainName = "test-name";
 
     it("Should fail if domain's encryptAtRest is undefined", async () => {
-        const args = createResourceValidationArgs(aws.elasticsearch.Domain, () => ({
+        const args = createResourceValidationArgs(aws.elasticsearch.Domain, {
             domainName: domainName,
-        }));
+        });
 
         const msg = `Elasticsearch domain ${domainName} must be encrypted at rest.`;
         await assertHasViolation(policy, args, { message: msg });
     });
     it("Should fail if domain's encryptAtRest is disabled", async () => {
-        const args = createResourceValidationArgs(aws.elasticsearch.Domain, () => ({
+        const args = createResourceValidationArgs(aws.elasticsearch.Domain, {
             domainName: domainName,
             encryptAtRest: {
                 enabled: false,
             },
-        }));
+        });
 
         const msg = `Elasticsearch domain ${domainName} must be encrypted at rest.`;
         await assertHasViolation(policy, args, { message: msg });
     });
 
     it("Should pass if encryptAtRest is enabled", async () => {
-        const args = createResourceValidationArgs(aws.elasticsearch.Domain, () => ({
+        const args = createResourceValidationArgs(aws.elasticsearch.Domain, {
             domainName: domainName,
             encryptAtRest: {
                 enabled: true,
             },
-        }));
+        });
 
         await assertNoViolations(policy, args);
     });
@@ -59,15 +59,15 @@ describe("#ElasticsearchInVpcOnly", () => {
     const policy = elasticsearch.ElasticsearchInVpcOnly("mandatory");
 
     it("Should fail if no VPC options are available", async () => {
-        const args = createResourceValidationArgs(aws.elasticsearch.Domain, () => ({}));
+        const args = createResourceValidationArgs(aws.elasticsearch.Domain, {});
 
         await assertHasViolation(policy, args, { message: "must run within a VPC." });
     });
 
     it("Should pass if VPC options are available", async () => {
-        const args = createResourceValidationArgs(aws.elasticsearch.Domain, () => ({
+        const args = createResourceValidationArgs(aws.elasticsearch.Domain, {
             vpcOptions: {},
-        }));
+        });
 
         await assertNoViolations(policy, args);
     });

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -24,21 +24,16 @@ import * as assert from "assert";
 // from the resource's constructor parameters.
 export function createResourceValidationArgs<TResource extends Resource, TArgs>(
     resourceClass: { new(name: string, args: TArgs, ...rest: any[]): TResource },
-    argsFactory: () => NonNullable<Unwrap<TArgs>>,
+    args: NonNullable<Unwrap<TArgs>>,
 ): policy.ResourceValidationArgs {
     const type = (<any>resourceClass).__pulumiType;
     if (typeof type !== "string") {
         assert.fail("Could not determine Pulumi type from resourceClass.");
     }
 
-    const result = argsFactory();
-    if (!result) {
-        assert.fail("Result from argsFactory must not be undefined.");
-    }
-
     return {
         type: type as string,
-        props: result,
+        props: args,
     };
 }
 


### PR DESCRIPTION
There's no need to use an `argsFactory` function. The args can be passed directly.