### PR TITLE
Customize AWS Guard policy packs for each integration test

### DIFF
--- a/integration-tests/awsguard.go
+++ b/integration-tests/awsguard.go
@@ -1,0 +1,138 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integrationtests
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"regexp"
+
+	"github.com/pkg/errors"
+
+	ptesting "github.com/pulumi/pulumi/pkg/testing"
+)
+
+// Regex used to verify that policy names are reasonable.
+var ruleNameRE = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_]{1,100}$")
+
+// awsGuardSettings contains the configuration specific to the version of the AWS Guard
+// policy pack to be used for the integration test. This is how any specific configuration
+// values can be used for the test. (e.g. disabling or configuring policies.)
+type awsGuardSettings struct {
+	// Enforcement level to use for all policies. ("" will default to "mandatory".)
+	defaultEnforcementLevel string
+
+	// Specific policies to disable. (Will set their individual enforcement levels to "disabled".)
+	disablePolicies []string
+}
+
+// validate confirms the settings present are reasonable. Since we are writing these settings
+// into JS code that gets executed, a malicious user could do some pretty nasty things without
+// safeguards in place.
+func (settings awsGuardSettings) validate() error {
+	// default enforcement level
+	switch settings.defaultEnforcementLevel {
+	case "", "advisory", "mandatory", "disabled":
+		// OK
+		break
+	default:
+		return errors.Errorf("unrecognized default enforcement level %q", settings.defaultEnforcementLevel)
+	}
+
+	// disabled rules
+	for _, policy := range settings.disablePolicies {
+		if !ruleNameRE.MatchString(policy) {
+			return errors.Errorf("policy name %q appears to be invalid", policy)
+		}
+	}
+
+	return nil
+}
+
+// CreatePolicyPack creates a new Node module in a sub folder of the test environment.
+// The awsGuardSettings will be written into the module's index.ts file.
+// Returns the path to the created module's directory.
+func (settings awsGuardSettings) CreatePolicyPack(e *ptesting.Environment) (string, error) {
+	e.Log("Creating customized AWS Guard module")
+
+	if err := settings.validate(); err != nil {
+		return "", errors.Wrap(err, "validation error")
+	}
+
+	initialCWD := e.CWD
+
+	moduleFolder := path.Join(e.RootPath, "custom-awsguard")
+	if err := os.Mkdir(moduleFolder, os.ModeDir|os.ModePerm); err != nil {
+		return "", errors.Wrap(err, "creating folder for customized AWS Guard module")
+	}
+
+	// package.json, defining the module itself.
+	packageJSONFilePath := path.Join(moduleFolder, "package.json")
+	packageJSONFileContents := `{
+		"name": "custom-awsguard",
+		"version": "1.0.0",
+		"description": "Customized AWS Guard policy pack for integration tests.",
+		"main": "index.js",
+		"dependencies": {
+			"@pulumi/aws": "latest",
+			"@pulumi/awsguard": "latest"
+		}
+	  }`
+	if err := ioutil.WriteFile(packageJSONFilePath, []byte(packageJSONFileContents), os.ModePerm); err != nil {
+		return "", errors.Wrap(err, "writing package.json")
+	}
+
+	// index.js, which contains encodes the settings via code.
+	indexTsFilePath := path.Join(moduleFolder, "index.js")
+	indexTsFileContents := settings.renderIndexJSFile()
+	if err := ioutil.WriteFile(indexTsFilePath, []byte(indexTsFileContents), os.ModePerm); err != nil {
+		return "", errors.Wrap(err, "writing index.js")
+	}
+
+	// Run `yarn` in the custom policy packs folder, to download the AWS Guard module as
+	// a dependency.
+	e.CWD = moduleFolder
+	e.RunCommand("yarn", "install")
+	e.RunCommand("yarn", "link", "@pulumi/awsguard")
+	e.CWD = initialCWD
+
+	return moduleFolder, nil
+}
+
+// renderIndexJSFile returns the contents of the customized index.js file.
+func (settings awsGuardSettings) renderIndexJSFile() string {
+	contents := bytes.NewBufferString(`// Generated code. Do not edit.
+const awsguard = require("@pulumi/awsguard");
+new awsguard.AwsGuard({
+`)
+
+	// Write the default enforcement level.
+	if settings.defaultEnforcementLevel == "" {
+		settings.defaultEnforcementLevel = "mandatory"
+	}
+	contents.WriteString(fmt.Sprintf("\tall: '%s',\n", settings.defaultEnforcementLevel))
+
+	// Configure every policy we wish to disable.
+	for _, policyToDisable := range settings.disablePolicies {
+		line := fmt.Sprintf("'%s': 'disabled',", policyToDisable)
+		contents.WriteString(fmt.Sprintf("\t%s\n", line))
+	}
+	contents.WriteString("});\n")
+
+	return contents.String()
+}

--- a/integration-tests/database_test.go
+++ b/integration-tests/database_test.go
@@ -15,21 +15,13 @@
 package integrationtests
 
 import (
-	"os"
-	"path"
 	"testing"
 )
 
 func TestDatabase(t *testing.T) {
-	// Get the directory for the policy pack to run. (The parent of this /integration-tests directory.)
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Error getting working directory")
-	}
-	policyPackDir := path.Join(cwd, "..")
-
 	runPolicyPackIntegrationTest(
-		t, "database", policyPackDir,
+		t, "database",
+		awsGuardSettings{},
 		map[string]string{
 			"aws:region": "us-west-2",
 		},

--- a/integration-tests/network_test.go
+++ b/integration-tests/network_test.go
@@ -15,21 +15,13 @@
 package integrationtests
 
 import (
-	"os"
-	"path"
 	"testing"
 )
 
 func TestNetwork(t *testing.T) {
-	// Get the directory for the policy pack to run. (The parent of this /integration-tests directory.)
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Error getting working directory")
-	}
-	policyPackDir := path.Join(cwd, "..")
-
 	runPolicyPackIntegrationTest(
-		t, "network", policyPackDir,
+		t, "network",
+		awsGuardSettings{},
 		map[string]string{
 			"aws:region": "us-west-2",
 		},

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,9 +24,19 @@ import "./storage";
 
 export { AwsGuard, AwsGuardArgs };
 
-// If we're running our integration tests, create a new instance of AwsGuard.
-// TODO[pulumi/pulumi-awsguard#34] Use an alternative approach to creating a new instance of AwsGuard
-// for the integration tests, rather than having this baked into the library itself.
-if (process.env["PULUMI_AWSGUARD_TESTING"] === "true") {
-    const awsGuard = new AwsGuard({ all: "mandatory" });
-}
+// To create a policy pack using all of the AWS Guard rules,  create
+// a new NPM module and add the following code:
+//
+// Using JavaScript
+//      const awsguard = require("@pulumi/awsguard");
+//      new awsguard.AwsGuard({ all: "mandatory" });
+//
+// Using TypeScript
+//      import { AwsGuard, AwsGuardArgs } from "@pulumi/awsguard";
+//      export policyPack = new AwsGuard({ all: "mandatory" });
+//
+// Though you may want to configure any individual rules or their
+// settings by writing more code.
+//
+// Fore more information on enabling and configuring AWS Guard, see:
+// https://www.pulumi.com/docs/guides/crossguard

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export { AwsGuard, AwsGuardArgs };
 //
 // Using TypeScript
 //      import { AwsGuard, AwsGuardArgs } from "@pulumi/awsguard";
-//      export policyPack = new AwsGuard({ all: "mandatory" });
+//      new AwsGuard({ all: "mandatory" });
 //
 // Though you may want to configure any individual rules or their
 // settings by writing more code.


### PR DESCRIPTION
Remove the temporary `PULUMI_AWSGUARD_TESTING` environment variable we were using, which was allowing us to use a "default" version of the AWS Guard module for integration tests.

With this change, we now create a new Node module named "custom-awsguard" for each integration test. This module will download @pulumi/awsguard and customize it as needed for the integration test.

(No tests require this functionality now, but as seen in https://github.com/pulumi/pulumi-awsguard/pull/39, disabling unrelated policies makes it easier to write integration tests.)

Fixes #34 