### PR TITLE
Fix build to allow `make ensure && make` work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,39 +1,14 @@
 PROJECT_NAME := awsguard
-NODE_MODULE_NAME := @pulumi/awsguard
+SUB_PROJECTS := src
 include build/common.mk
-
-VERSION := $(shell ./scripts/get-version.sh)
 
 .PHONY: ensure
 ensure::
-	yarn install --cwd ./src/
-
 	# Golang dependencies for the integration tests.
 	go get -t -d ./integration-tests
 
-.PHONY: build
-build::
-	# Clean
-	rm -rf bin/
-
-	# Build
-	cd src && yarn run build
-
-	# Set version and copy non-source assets.
-	sed -e 's/\$${VERSION}/$(VERSION)/g' < ./src/package.json > bin/package.json
-	cp README.md LICENSE ./bin/
-	node ./scripts/reversion.js bin/version.js ${VERSION}
-
-.PHONY: lint
-lint::
-	cd src && yarn run lint
-
-test_fast::
-	cd src && yarn run test
-
 .PHONY: test_all
 test_all::
-	$(MAKE) test_fast
 	go test ./integration-tests/ -v -timeout 30m
 
 .PHONY: publish
@@ -43,6 +18,6 @@ publish:
 # The travis_* targets are entrypoints for CI.
 .PHONY: travis_cron travis_push travis_pull_request travis_api
 travis_cron: all
-travis_push: lint build test_all publish
-travis_pull_request: lint build test_all
+travis_push: only_build only_test publish
+travis_pull_request: all
 travis_api: all

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -4,16 +4,16 @@ set -o nounset -o errexit -o pipefail
 
 echo "Publishing to NPMjs.com:"
 
-if [ ! -f "./bin/index.js" ]; then
-    echo "Error: ./bin/index.js not found. Do you need to build?"
+if [ ! -f "./src/bin/index.js" ]; then
+    echo "Error: ./src/bin/index.js not found. Do you need to build?"
     exit 1
 fi
 
 node $(dirname $0)/promote.js ${@:2} < \
-    ./bin/package.json > \
-    ./bin/package.json.publish
+    ./src/bin/package.json > \
+    ./src/bin/package.json.publish
 
-cd ./bin/
+cd ./src/bin/
 
 mv package.json package.json.dev
 mv package.json.publish package.json

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,22 @@
+PROJECT_NAME := awsguard
+NODE_MODULE_NAME := @pulumi/awsguard
+include ../build/common.mk
+
+VERSION := $(shell ../scripts/get-version.sh)
+
+build::
+	yarn install
+	rm -rf bin/
+	yarn build
+	sed -e 's/\$${VERSION}/$(VERSION)/g' < package.json > bin/package.json
+	cp ../README.md ../LICENSE bin/
+	node ../scripts/reversion.js bin/version.js ${VERSION}
+
+lint::
+	yarn run lint
+
+test_fast::
+	yarn run test
+
+test_all::
+	yarn run test

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "outDir": "../bin",
+        "outDir": "bin",
         "target": "es6",
         "module": "commonjs",
         "moduleResolution": "node",


### PR DESCRIPTION
It was currently expecting a `yarn.lock` in the root dir, but now that we have moved the source under `./src`, this no longer works (unless you had an old `yarn.lock` file sticking around in the root dir). Update to just use a sub project Makefile, like we do elsewhere.