### PR TITLE
Remove dependency on `@pulumi/aws` from integration test policy pack

### DIFF
--- a/integration-tests/awsguard.go
+++ b/integration-tests/awsguard.go
@@ -95,7 +95,6 @@ func (settings awsGuardSettings) CreatePolicyPack(e *ptesting.Environment) (stri
 		"description": "Customized AWS Guard policy pack for integration tests.",
 		"main": "index.js",
 		"dependencies": {
-			"@pulumi/aws": "latest",
 			"@pulumi/awsguard": "latest"
 		}
 	  }`


### PR DESCRIPTION
`@pulumi/awsguard` itself depends on `@pulumi/aws`, so there should be no need to specify it here. (This also avoids issues currently where "latest" is picking up the 2.0 beta release of `@pulumi/aws`).