### PR TITLE
Expose ApiGatewayEndpointTypeArgs interface

### DIFF
--- a/src/apiGateway.ts
+++ b/src/apiGateway.ts
@@ -55,7 +55,6 @@ export const apiGatewayMethodCachedAndEncrypted: ResourceValidationPolicy = {
 };
 registerPolicy("apiGatewayMethodCachedAndEncrypted", apiGatewayMethodCachedAndEncrypted);
 
-/** @internal */
 export interface ApiGatewayEndpointTypeArgs {
     /**
      * Whether or not API Endpoint type EDGE is allowed. Will default to true


### PR DESCRIPTION
Attempting to compile the simple example given resulted in the following error from the typescript compiler.
```typescript
import {AwsGuard} from '@pulumi/awsguard';
new AwsGuard({all: 'advisory'});
```
```
node_modules/@pulumi/awsguard/apiGateway.d.ts:7:54 - error TS2304: Cannot find name 'ApiGatewayEndpointTypeArgs'.

7         apiGatewayEndpointType?: EnforcementLevel | (ApiGatewayEndpointTypeArgs & PolicyArgs);
```

I believe this is due to `ApiGatewayEndpointTypeArgs` being marked as `@internal` unlike other argument declarations.  This PR simply removes the `@internal` decoration on the interface.