### PR TITLE
Fix flaky test

### DIFF
--- a/src/tests/security.spec.ts
+++ b/src/tests/security.spec.ts
@@ -135,7 +135,7 @@ describe("#iamAccessKeysRotated", () => {
             maxKeyAge: 30,
         });
         await assertHasStackViolation(policy, args, {
-            message: "access key must be rotated within 30 days (key is 180 days old)",
+            message: "access key must be rotated within 30 days",
         });
     });
 });


### PR DESCRIPTION
When I was running the tests locally this morning, this was failing because the actual violation message differed from the expected one:

Expected: -
Actual: +

```diff
- access key must be rotated within 30 days (key is 180 days old)
+ access key must be rotated within 30 days (key is 179 days old)
```

This change loosens the test slightly to only check for the first part of the message -- the important thing is that we're checking that a violation occurs as expected, which is still the case.