### PR TITLE
Update integration tests to use TypeScript rather than JavaScript

### DIFF
--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -17,7 +17,7 @@ package integrationtests
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -51,7 +51,7 @@ func runPolicyPackIntegrationTest(
 	if err != nil {
 		t.Fatalf("Error getting working directory")
 	}
-	testProgramDir := path.Join(cwd, pulumiProgramDir)
+	testProgramDir := filepath.Join(cwd, pulumiProgramDir)
 
 	stackName := fmt.Sprintf("%s-%d", pulumiProgramDir, time.Now().Unix()%100000)
 


### PR DESCRIPTION
We had an issue that prevented use of the library from compiling with TypeScript, so update the integration test to use TypeScript so we can ensure it compiles.

Fixes https://github.com/pulumi/pulumi-policy-aws/issues/62