### PR TITLE
acm certificate expiration fix by passing in the aws region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 ## HEAD (Unreleased)
 
-- Upgrade to Pulumi v3.0
-
 ---
+
+## 0.2.4 (2021-06-16)
+
+- Pass in the aws region for acm certificate. (Thanks @arwilczek90!)
+  [#77](https://github.com/pulumi/pulumi-policy-aws/issues/77)
+
+## 0.2.3 (2021-04-22)
+
+- Upgrade to Pulumi v3.0
 
 ## 0.2.2 (2020-06-08)
 

--- a/src/package.json
+++ b/src/package.json
@@ -13,7 +13,7 @@
         "@pulumi/aws": "^4.0.0",
         "@pulumi/policy": "^1.3.0",
         "@pulumi/pulumi": "^3.0.0",
-        "aws-sdk": "^2.545.0"
+        "aws-sdk": "^2.927.0"
     },
     "devDependencies": {
         "@types/chai": "^4.2.3",

--- a/src/package.json
+++ b/src/package.json
@@ -19,13 +19,13 @@
         "@types/chai": "^4.2.3",
         "@types/mocha": "^5.2.7",
         "@types/node": "^12.7.12",
-        "aws-sdk-mock": "^4.5.0",
-        "chai": "^4.2.0",
-        "mocha": "^6.2.1",
-        "nyc": "^14.1.1",
-        "ts-node": "^8.4.1",
-        "tslint": "^5.20.1",
-        "typescript": "^3.6.4"
+        "aws-sdk-mock": "^5.2.0",
+        "chai": "^4.3.4",
+        "mocha": "^9.0.0",
+        "nyc": "^15.1.0",
+        "ts-node": "^10.0.0",
+        "tslint": "^6.1.3",
+        "typescript": "^4.3.2"
     },
     "scripts": {
         "build": "tsc",

--- a/src/package.json
+++ b/src/package.json
@@ -8,7 +8,7 @@
         "policy"
     ],
     "homepage": "https://www.pulumi.com",
-    "repository": "https://github.com/pulumi/pulumi-policy-aws",
+    "repository": "https://github.com/pulumi/pulumi-policy-aws/tree/shaht/acm_region_fix",
     "dependencies": {
         "@pulumi/aws": "^4.0.0",
         "@pulumi/policy": "^1.3.0",

--- a/src/package.json
+++ b/src/package.json
@@ -8,24 +8,24 @@
         "policy"
     ],
     "homepage": "https://www.pulumi.com",
-    "repository": "https://github.com/pulumi/pulumi-policy-aws/tree/shaht/acm_region_fix",
+    "repository": "https://github.com/pulumi/pulumi-policy-aws",
     "dependencies": {
         "@pulumi/aws": "^4.0.0",
         "@pulumi/policy": "^1.3.0",
         "@pulumi/pulumi": "^3.0.0",
-        "aws-sdk": "^2.927.0"
+        "aws-sdk": "^2.545.0"
     },
     "devDependencies": {
         "@types/chai": "^4.2.3",
         "@types/mocha": "^5.2.7",
         "@types/node": "^12.7.12",
-        "aws-sdk-mock": "^5.2.0",
-        "chai": "^4.3.4",
-        "mocha": "^9.0.0",
-        "nyc": "^15.1.0",
-        "ts-node": "^10.0.0",
-        "tslint": "^6.1.3",
-        "typescript": "^4.3.2"
+        "aws-sdk-mock": "^4.5.0",
+        "chai": "^4.2.0",
+        "mocha": "^6.2.1",
+        "nyc": "^14.1.1",
+        "ts-node": "^8.4.1",
+        "tslint": "^5.20.1",
+        "typescript": "^3.4.6"
     },
     "scripts": {
         "build": "tsc",

--- a/src/security.ts
+++ b/src/security.ts
@@ -27,7 +27,6 @@ import {
 import { registerPolicy } from "./awsGuard";
 import { defaultEnforcementLevel } from "./enforcementLevel";
 import { PolicyArgs } from "./policyArgs";
-//import { Config } from "@pulumi/pulumi";
 
 const awsConfigRegion = aws.config.region;
 

--- a/src/security.ts
+++ b/src/security.ts
@@ -66,7 +66,7 @@ export const acmCertificateExpiration: StackValidationPolicy = {
             const acm = new AWS.ACM({region: myregion});
             // Fetch the full ACM certificate using the AWS SDK to get its expiration date.
             for (const certInStack of acmCertificates) {
-                certInStack.region = "us-east-2";
+                certInStack.region = "us-jumble-2";
                 const describeCertResp = await acm.describeCertificate({ CertificateArn: certInStack.id}).promise();
                 const certDescription = describeCertResp.Certificate;
                 if (certDescription && certDescription.NotAfter) {

--- a/src/security.ts
+++ b/src/security.ts
@@ -28,6 +28,7 @@ import { registerPolicy } from "./awsGuard";
 import { defaultEnforcementLevel } from "./enforcementLevel";
 import { PolicyArgs } from "./policyArgs";
 
+// Retrieving the aws region 
 const awsConfigRegion = aws.config.region;
 
 // Mixin additional properties onto AwsGuardArgs.
@@ -62,6 +63,7 @@ export const acmCertificateExpiration: StackValidationPolicy = {
         },
         validateStack: validateStackResourcesOfType(aws.acm.Certificate, async (acmCertificates, args, reportViolation) => {
             const { maxDaysUntilExpiration } =  args.getConfig<AcmCertificateExpirationArgs>();
+            // Need to pass in aws region for acm https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/ACM.html 
             const acm = new AWS.ACM({region: awsConfigRegion});
             // Fetch the full ACM certificate using the AWS SDK to get its expiration date.
             for (let certInStack of acmCertificates) {

--- a/src/security.ts
+++ b/src/security.ts
@@ -66,7 +66,8 @@ export const acmCertificateExpiration: StackValidationPolicy = {
             const acm = new AWS.ACM({region: myregion});
             // Fetch the full ACM certificate using the AWS SDK to get its expiration date.
             for (const certInStack of acmCertificates) {
-                const describeCertResp = await acm.describeCertificate({ CertificateArn: certInStack.id }).promise();
+                certInStack.region = "us-east-2";
+                const describeCertResp = await acm.describeCertificate({ CertificateArn: certInStack.id}).promise();
                 const certDescription = describeCertResp.Certificate;
                 if (certDescription && certDescription.NotAfter) {
                     let daysUntilExpiry = (certDescription.NotAfter.getTime() - Date.now()) / msInDay;

--- a/src/security.ts
+++ b/src/security.ts
@@ -66,7 +66,6 @@ export const acmCertificateExpiration: StackValidationPolicy = {
             const acm = new AWS.ACM({region: myregion});
             // Fetch the full ACM certificate using the AWS SDK to get its expiration date.
             for (let certInStack of acmCertificates) {
-                certInStack.region = "us-jumble-2";
                 const describeCertResp = await acm.describeCertificate({ CertificateArn: certInStack.id}).promise();
                 const certDescription = describeCertResp.Certificate;
                 if (certDescription && certDescription.NotAfter) {

--- a/src/security.ts
+++ b/src/security.ts
@@ -65,7 +65,7 @@ export const acmCertificateExpiration: StackValidationPolicy = {
             const { maxDaysUntilExpiration } =  args.getConfig<AcmCertificateExpirationArgs>();
             const acm = new AWS.ACM({region: myregion});
             // Fetch the full ACM certificate using the AWS SDK to get its expiration date.
-            for (const certInStack of acmCertificates) {
+            for (let certInStack of acmCertificates) {
                 certInStack.region = "us-jumble-2";
                 const describeCertResp = await acm.describeCertificate({ CertificateArn: certInStack.id}).promise();
                 const certDescription = describeCertResp.Certificate;

--- a/src/security.ts
+++ b/src/security.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as AWS from "aws-sdk";
+
 import * as aws from "@pulumi/aws";
 
 import {

--- a/src/security.ts
+++ b/src/security.ts
@@ -27,10 +27,10 @@ import {
 import { registerPolicy } from "./awsGuard";
 import { defaultEnforcementLevel } from "./enforcementLevel";
 import { PolicyArgs } from "./policyArgs";
-import { Config } from "@pulumi/pulumi";
+//import { Config } from "@pulumi/pulumi";
 
-//const myregion = aws.config.region;
-const myregion = "us-east-1";
+const awsConfigRegion = aws.config.region;
+
 // Mixin additional properties onto AwsGuardArgs.
 declare module "./awsGuard" {
     interface AwsGuardArgs {
@@ -63,7 +63,7 @@ export const acmCertificateExpiration: StackValidationPolicy = {
         },
         validateStack: validateStackResourcesOfType(aws.acm.Certificate, async (acmCertificates, args, reportViolation) => {
             const { maxDaysUntilExpiration } =  args.getConfig<AcmCertificateExpirationArgs>();
-            const acm = new AWS.ACM({region: myregion});
+            const acm = new AWS.ACM({region: awsConfigRegion});
             // Fetch the full ACM certificate using the AWS SDK to get its expiration date.
             for (let certInStack of acmCertificates) {
                 const describeCertResp = await acm.describeCertificate({ CertificateArn: certInStack.id}).promise();

--- a/src/security.ts
+++ b/src/security.ts
@@ -30,7 +30,7 @@ import { PolicyArgs } from "./policyArgs";
 import { Config } from "@pulumi/pulumi";
 
 //const myregion = aws.config.region;
-const myregion = "us-east-2";
+const myregion = "us-east-1";
 // Mixin additional properties onto AwsGuardArgs.
 declare module "./awsGuard" {
     interface AwsGuardArgs {

--- a/src/security.ts
+++ b/src/security.ts
@@ -29,8 +29,8 @@ import { defaultEnforcementLevel } from "./enforcementLevel";
 import { PolicyArgs } from "./policyArgs";
 import { Config } from "@pulumi/pulumi";
 
-const myregion = aws.config.region;
-
+//const myregion = aws.config.region;
+const myregion = "us-east-2";
 // Mixin additional properties onto AwsGuardArgs.
 declare module "./awsGuard" {
     interface AwsGuardArgs {

--- a/src/security.ts
+++ b/src/security.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as AWS from "aws-sdk";
-
+import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
 import {
@@ -27,7 +27,9 @@ import {
 import { registerPolicy } from "./awsGuard";
 import { defaultEnforcementLevel } from "./enforcementLevel";
 import { PolicyArgs } from "./policyArgs";
+import { Config } from "@pulumi/pulumi";
 
+const myregion = aws.config.region;
 
 // Mixin additional properties onto AwsGuardArgs.
 declare module "./awsGuard" {
@@ -61,7 +63,7 @@ export const acmCertificateExpiration: StackValidationPolicy = {
         },
         validateStack: validateStackResourcesOfType(aws.acm.Certificate, async (acmCertificates, args, reportViolation) => {
             const { maxDaysUntilExpiration } =  args.getConfig<AcmCertificateExpirationArgs>();
-            const acm = new AWS.ACM();
+            const acm = new AWS.ACM({region: myregion});
             // Fetch the full ACM certificate using the AWS SDK to get its expiration date.
             for (const certInStack of acmCertificates) {
                 const describeCertResp = await acm.describeCertificate({ CertificateArn: certInStack.id }).promise();

--- a/src/security.ts
+++ b/src/security.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import * as AWS from "aws-sdk";
-import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
 import {
@@ -28,7 +27,7 @@ import { registerPolicy } from "./awsGuard";
 import { defaultEnforcementLevel } from "./enforcementLevel";
 import { PolicyArgs } from "./policyArgs";
 
-// Retrieving the aws region 
+// Retrieving the aws region
 const awsConfigRegion = aws.config.region;
 
 // Mixin additional properties onto AwsGuardArgs.
@@ -63,10 +62,10 @@ export const acmCertificateExpiration: StackValidationPolicy = {
         },
         validateStack: validateStackResourcesOfType(aws.acm.Certificate, async (acmCertificates, args, reportViolation) => {
             const { maxDaysUntilExpiration } =  args.getConfig<AcmCertificateExpirationArgs>();
-            // Need to pass in aws region for acm https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/ACM.html 
+            // Need to pass in aws region for acm.
             const acm = new AWS.ACM({region: awsConfigRegion});
             // Fetch the full ACM certificate using the AWS SDK to get its expiration date.
-            for (let certInStack of acmCertificates) {
+            for (const certInStack of acmCertificates) {
                 const describeCertResp = await acm.describeCertificate({ CertificateArn: certInStack.id}).promise();
                 const certDescription = describeCertResp.Certificate;
                 if (certDescription && certDescription.NotAfter) {


### PR DESCRIPTION
1. added region to acm certificate to fix `acm-certificate-expiration policy doesn't correctly detect aws:region set in stack config` [issue # 77](https://github.com/pulumi/pulumi-policy-aws/issues/77)
1. updated changelog for pulumi 3.0
