### PR TITLE
Fix compile errors

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,10 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
-          registry-url: https://registry.npmjs.org
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.2.0
         with:
@@ -58,10 +57,9 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
-          registry-url: https://registry.npmjs.org
       - name: Ensure dependencies
         run: make ensure
       - name: Checkout Scripts Repo
@@ -100,7 +98,7 @@ jobs:
       matrix:
         platform: [ ubuntu-latest ]
         go-version: [ 1.17.x ]
-        node-version: [ 14.x ]
+        node-version: [ 20 ]
 name: master
 "on":
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
-          registry-url: https://registry.npmjs.org
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.2.0
         with:
@@ -58,10 +57,9 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
-          registry-url: https://registry.npmjs.org
       - name: Ensure dependencies
         run: make ensure
       - name: Checkout Scripts Repo
@@ -100,7 +98,7 @@ jobs:
       matrix:
         platform: [ ubuntu-latest ]
         go-version: [ 1.17.x ]
-        node-version: [ 14.x ]
+        node-version: [ 20 ]
   create_docs_build:
     name: Create docs build
     needs: build_test_publish

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -31,10 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
-          registry-url: https://registry.npmjs.org
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.2.0
         with:
@@ -77,10 +76,9 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
-          registry-url: https://registry.npmjs.org
       - name: Ensure dependencies
         run: make ensure
       - name: Checkout Scripts Repo
@@ -110,7 +108,7 @@ jobs:
       matrix:
         platform: [ ubuntu-latest ]
         go-version: [ 1.17.x ]
-        node-version: [ 14.x ]     
+        node-version: [ 20 ]
 name: Run Acceptance Tests from PR
 on:
   repository_dispatch:

--- a/build/common.mk
+++ b/build/common.mk
@@ -99,9 +99,7 @@ STEP_MESSAGE = @echo -e "\033[0;32m$(shell echo '$@' | tr a-z A-Z | tr '_' ' '):
 
 # Our install targets place items item into $PULUMI_ROOT, if it's
 # unset, default to /opt/pulumi.
-ifeq ($(PULUMI_ROOT),)
-	PULUMI_ROOT:=/opt/pulumi
-endif
+PULUMI_ROOT ?= $$HOME/.pulumi-dev
 
 PULUMI_BIN          := $(PULUMI_ROOT)/bin
 PULUMI_NODE_MODULES := $(PULUMI_ROOT)/node_modules

--- a/integration-tests/awsguard.go
+++ b/integration-tests/awsguard.go
@@ -93,8 +93,9 @@ func (settings awsGuardSettings) CreatePolicyPack(e *ptesting.Environment) (stri
 		"name": "custom-awsguard",
 		"version": "1.0.0",
 		"description": "Customized AWS Guard policy pack for integration tests.",
-		"dependencies": {
-			"@pulumi/awsguard": "latest"
+		"devDependencies": {
+			"@types/node": "^18.11.9",
+			"typescript": "^5.3.3"
 		}
 	}`
 	if err := ioutil.WriteFile(packageJSONFilePath, []byte(packageJSONFileContents), os.ModePerm); err != nil {

--- a/integration-tests/compute/index.ts
+++ b/integration-tests/compute/index.ts
@@ -23,9 +23,9 @@ console.log(`Running test scenario #${testScenario}`);
 const ami = pulumi.output(aws.ec2.getAmi({
     filters: [{
         name: "name",
-        values: ["amzn-ami-hvm-*"],
+        values: ["amzn2-ami-k*-hvm-*-x86_64-gp2"],
     }],
-    owners: ["137112412989"], // This owner ID is Amazon
+    owners: ["amazon"],
     mostRecent: true,
 }));
 

--- a/src/enforcementLevel.ts
+++ b/src/enforcementLevel.ts
@@ -28,6 +28,7 @@ export function isEnforcementLevel(o: any): o is EnforcementLevel {
             case "advisory":
             case "disabled":
             case "mandatory":
+            case "remediate":
                 return true;
             default:
                 return exhaustiveFalse(enforcementLevel);

--- a/src/tests/util.ts
+++ b/src/tests/util.ts
@@ -103,6 +103,9 @@ async function runResourcePolicy(resPolicy: policy.ResourceValidationPolicy, arg
         ? resPolicy.validateResource
         : [resPolicy.validateResource];
     for (const validation of validations) {
+        if (!validation) {
+            throw Error("validateResource must be a function or array of functions.");
+        }
         await Promise.resolve(validation(args, report));
     }
     return violations;


### PR DESCRIPTION
The `@pulumi/policy` library was updated to support remediations, but this repo hasn't been updated since then. This commit fixes some compile errors due to the changes there.

```
$ tsc
enforcementLevel.ts:33:40 - error TS2345: Argument of type '"remediate"' is not assignable to parameter of type 'never'.

33                 return exhaustiveFalse(enforcementLevel);
                                          ~~~~~~~~~~~~~~~~

tests/util.ts:106:31 - error TS2722: Cannot invoke an object which is possibly 'undefined'.

106         await Promise.resolve(validation(args, report));
                                  ~~~~~~~~~~


Found 2 errors.
```

Note: This points out that we're missing a daily cron in this repro to catch these things sooner. Opened #102

Fixes #101