### PR TITLE
Fix publishing to npm

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
+          registry-url: https://registry.npmjs.org
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.2.0
         with:
@@ -60,6 +61,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
+          registry-url: https://registry.npmjs.org
       - name: Ensure dependencies
         run: make ensure
       - name: Checkout Scripts Repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
+          registry-url: https://registry.npmjs.org
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.2.0
         with:
@@ -60,6 +61,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
+          registry-url: https://registry.npmjs.org
       - name: Ensure dependencies
         run: make ensure
       - name: Checkout Scripts Repo

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
+          registry-url: https://registry.npmjs.org
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.2.0
         with:
@@ -79,6 +80,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
+          registry-url: https://registry.npmjs.org
       - name: Ensure dependencies
         run: make ensure
       - name: Checkout Scripts Repo


### PR DESCRIPTION
When upgrading `setup-node` in https://github.com/pulumi/pulumi-policy-aws/pull/103, I stripped the `registry-url` property thinking it wasn't necessary, but it's actually needed to configure credentials correctly with `NPM_TOKEN` for publishing to npm. This change adds `registry-url` back.

Fixes #105