### PR TITLE
feat: add new securityGroupNoRuleManagementConflicts rule

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           path: ci-scripts
           repository: pulumi/scripts
+      - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           path: ci-scripts
           repository: pulumi/scripts
+      - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -88,6 +88,7 @@ jobs:
         with:
           path: ci-scripts
           repository: pulumi/scripts
+      - run: echo "ci-scripts" >> .git/info/exclude # actions/checkout#197
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 **/package-lock.json
 
 yarn-error.log
+**/Pulumi.*.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## HEAD (Unreleased)
+
+## 0.5.0
 
 - Added in checks for `alb` and `lb` to the compute and network policies
-
----
+- add new securityGroupNoRuleManagementConflicts rule [#108](https://github.com/pulumi/pulumi-policy-aws/pull/108)
 
 ## 0.4.0 (2022-09-22)
 

--- a/integration-tests/compute/package.json
+++ b/integration-tests/compute/package.json
@@ -3,10 +3,10 @@
     "main": "index.ts",
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/aws": "^4.0.0",
+        "@pulumi/aws": "^6.0.0",
         "@pulumi/awsx": "^0.30.0"
     },
     "resolutions": {
-        "@pulumi/aws": "^4.0.0"
+        "@pulumi/aws": "^6.0.0"
     }
 }

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -250,5 +250,37 @@ func TestComputeEC2(t *testing.T) {
 					"The EC2 instance root block device must be encrypted.",
 				},
 			},
+			// Test scenario 10 - A egress type SecurityGroupRule attached to a SecurityGroup with inline rules
+			{
+				WantErrors: []string{
+					"mandatory",
+					"security-group-no-rule-management-conflicts",
+					"SecurityGroupRule test-sg-rule defines rules for SecurityGroup test-sg which has inline 'egress' rules",
+				},
+			},
+			// Test scenario 11 - A ingress type SecurityGroupRule attached to a SecurityGroup with inline rules
+			{
+				WantErrors: []string{
+					"mandatory",
+					"security-group-no-rule-management-conflicts",
+					"SecurityGroupRule test-sg-rule defines rules for SecurityGroup test-sg which has inline 'ingress' rules",
+				},
+			},
+			// Test scenario 12 - A SecurityGroupIngressRule attached to a SecurityGroup with inline rules
+			{
+				WantErrors: []string{
+					"mandatory",
+					"security-group-no-rule-management-conflicts",
+					"SecurityGroupIngressRule test-sg-ingress-rule defines rules for SecurityGroup test-sg which has inline 'ingress' rules",
+				},
+			},
+			// Test scenario 13 - A SecurityGroupEgressRule attached to a SecurityGroup with inline rules
+			{
+				WantErrors: []string{
+					"mandatory",
+					"security-group-no-rule-management-conflicts",
+					"SecurityGroupEgressRule test-sg-egress-rule defines rules for SecurityGroup test-sg which has inline 'egress' rules",
+				},
+			},
 		})
 }

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -211,12 +211,12 @@ export const securityGroupNoRuleManagementConflicts: StackValidationPolicy = {
           }
           if (type === "ingress" && dep.props["ingress"] && dep.props["ingress"].length > 0) {
             reportViolation(
-              `${currentType} ${resource.name} defines rules for SecurityGroup ${dep.name} which has inline 'ingress' rules`,
+              `${currentType} ${resource.name} defines rules for SecurityGroup ${dep.name} which has inline 'ingress' rules`, resource.urn,
             );
           }
           if (type === "egress" && dep.props["egress"] && dep.props["egress"].length > 0) {
             reportViolation(
-              `${currentType} ${resource.name} defines rules for SecurityGroup ${dep.name} which has inline 'egress' rules`,
+              `${currentType} ${resource.name} defines rules for SecurityGroup ${dep.name} which has inline 'egress' rules`, resource.urn,
             );
           }
         });

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -14,7 +14,14 @@
 
 import * as aws from "@pulumi/aws";
 
-import { EnforcementLevel, ResourceValidationPolicy, validateResourceOfType } from "@pulumi/policy";
+import {
+    EnforcementLevel,
+    ReportViolation,
+    ResourceValidationPolicy,
+    StackValidationArgs,
+    StackValidationPolicy,
+    validateResourceOfType,
+} from "@pulumi/policy";
 
 import { registerPolicy } from "./awsGuard";
 import { PolicyArgs } from "./policyArgs";
@@ -27,6 +34,7 @@ declare module "./awsGuard" {
         ec2VolumeInUse?: EnforcementLevel | (Ec2VolumeInUseArgs & PolicyArgs);
         elbAccessLoggingEnabled?: EnforcementLevel;
         encryptedVolumes?: EnforcementLevel | (EncryptedVolumesArgs & PolicyArgs);
+        securityGroupNoRuleManagementConflicts?: EnforcementLevel;
     }
 }
 
@@ -168,3 +176,52 @@ export const encryptedVolumes: ResourceValidationPolicy = {
     }),
 };
 registerPolicy("encryptedVolumes", encryptedVolumes);
+
+/** @internal */
+export const securityGroupNoRuleManagementConflicts: StackValidationPolicy = {
+  name: "security-group-no-rule-management-conflicts",
+  description:
+    "Checks that ec2.SecurityGroup resources do not conflict with vpc.SecurityGroupEgressRule, vpc.SecurityGroupIngressRule, or ec2.SecurityGroupRule.\n"+
+    "See https://www.pulumi.com/registry/packages/aws/api-docs/ec2/securitygroup/ for more details",
+  validateStack: (args: StackValidationArgs, reportViolation: ReportViolation) => {
+    args.resources.forEach((resource) => {
+      let currentType: string;
+      let type: "ingress" | "egress";
+      switch (resource.type) {
+        case "aws:vpc/securityGroupEgressRule:SecurityGroupEgressRule":
+          currentType = "SecurityGroupEgressRule";
+          type = "egress";
+          break;
+        case "aws:vpc/securityGroupIngressRule:SecurityGroupIngressRule":
+          currentType = "SecurityGroupIngressRule";
+          type = "ingress";
+          break;
+        case "aws:ec2/securityGroupRule:SecurityGroupRule":
+          currentType = "SecurityGroupRule";
+          type = resource.props["type"];
+          break;
+        default:
+            return;
+      }
+
+      if (resource.propertyDependencies["securityGroupId"]) {
+        resource.propertyDependencies["securityGroupId"].forEach((dep) => {
+          if (dep.type !== "aws:ec2/securityGroup:SecurityGroup" || !dep.props) {
+            return;
+          }
+          if (type === "ingress" && dep.props["ingress"] && dep.props["ingress"].length > 0) {
+            reportViolation(
+              `${currentType} ${resource.name} defines rules for SecurityGroup ${dep.name} which has inline 'ingress' rules`,
+            );
+          }
+          if (type === "egress" && dep.props["egress"] && dep.props["egress"].length > 0) {
+            reportViolation(
+              `${currentType} ${resource.name} defines rules for SecurityGroup ${dep.name} which has inline 'egress' rules`,
+            );
+          }
+        });
+      }
+    });
+  },
+};
+registerPolicy("securityGroupNoRuleManagementConflicts", securityGroupNoRuleManagementConflicts);


### PR DESCRIPTION
The
[docs](https://www.pulumi.com/registry/packages/aws/api-docs/ec2/securitygroup/) have strongly worded note about not using inline rules along with separate security group resources. This PR adds a new rule which will warn the user when they use both together.

re pulumi/pulumi-aws#3788